### PR TITLE
Update table_auto_delete.cronjob.php

### DIFF
--- a/lib/table_auto_delete.cronjob.php
+++ b/lib/table_auto_delete.cronjob.php
@@ -4,7 +4,8 @@ class rex_cronjob_table_auto_delete extends rex_cronjob
 {
     public function execute()
     {
-        rex_sql::factory()->query('DELETE FROM ' . $this->getParam('rex_table') . ' WHERE ' . (string) $this->getParam('field') . ' < MONTH(NOW() - INTERVAL ' . (int) $this->getParam('interval') . ' MONTH)');
+        $sql = rex_sql::factory();
+        $sql->setQuery('DELETE FROM ' . $this->getParam('rex_table') . ' WHERE ' . (string) $this->getParam('field') . ' < DATE_SUB(NOW(), INTERVAL ' . (int) $this->getParam('interval') . ' MONTH)');
 
         $this->setMessage('Datensätze in der Tabelle ' . $this->getParam('rex_table') . ' gelöscht, die älter als ' . $this->getParam('interval') . ' Monate waren.');
         return true;


### PR DESCRIPTION
Fixes #6
1. Korrigiert ->query zu ->setQuery
2. Der Vergleich createdate < MONTH(NOW() - INTERVAL 6 MONTH) ist nicht korrekt. Die Funktion MONTH() gibt nur die Monatszahl (1-12) zurück, während createdate wahrscheinlich ein Datum oder Zeitstempel ist.